### PR TITLE
Update DotMinecraft.cs

### DIFF
--- a/source/Craft.Net.Client/DotMinecraft.cs
+++ b/source/Craft.Net.Client/DotMinecraft.cs
@@ -11,7 +11,7 @@ namespace Craft.Net.Client
             if (RuntimeInfo.IsLinux)
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".minecraft");
             if (RuntimeInfo.IsMacOSX)
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Application Support", ".minecraft");
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Application Support", ".minecraft");
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft");
         }
     }


### PR DESCRIPTION
It seemed as though this was meant to be returned. Without the return statement OSX would use the application Data folder, which may not exist.
