### PR TITLE
add a packet handler to update the world on BlockChange packets

### DIFF
--- a/source/Craft.Net.Client/Handlers/PacketHandlers.cs
+++ b/source/Craft.Net.Client/Handlers/PacketHandlers.cs
@@ -22,6 +22,7 @@ namespace Craft.Net.Client.Handlers
 
             client.RegisterPacketHandler(typeof(MapChunkBulkPacket), WorldHandlers.MapChunkBulk);
             client.RegisterPacketHandler(typeof(ChunkDataPacket), WorldHandlers.ChunkData);
+            client.RegisterPacketHandler(typeof(BlockChangePacket), WorldHandlers.BlockChange);
         }
 
         public static void KeepAlive(MinecraftClient client, IPacket _packet)

--- a/source/Craft.Net.Client/Handlers/WorldHandlers.cs
+++ b/source/Craft.Net.Client/Handlers/WorldHandlers.cs
@@ -79,6 +79,14 @@ namespace Craft.Net.Client.Handlers
             }
         }
 
+        public static void BlockChange(MinecraftClient client, IPacket _packet)
+        {
+          var packet = (BlockChangePacket)_packet;
+          var position = new Coordinates3D(packet.X, packet.Y, packet.Z);
+          client.World.SetBlockId(position, (short)packet.BlockType);
+          client.World.SetMetadata(position, packet.BlockMetadata);
+        }
+
         public static void ChunkData(MinecraftClient client, IPacket _packet)
         {
             var packet = (ChunkDataPacket)_packet;

--- a/source/Craft.Net.Client/ReadOnlyWorld.cs
+++ b/source/Craft.Net.Client/ReadOnlyWorld.cs
@@ -38,6 +38,14 @@ namespace Craft.Net.Client
             return World.GetBlockId(coordinates);
         }
 
+        internal void SetBlockId(Coordinates3D coordinates, short value) {
+          World.SetBlockId(coordinates, value);
+        }
+
+        internal void SetMetadata(Coordinates3D coordinates, byte value) {
+          World.SetMetadata(coordinates, value);
+        }
+
         public byte GetMetadata(Coordinates3D coordinates)
         {
             return World.GetMetadata(coordinates);


### PR DESCRIPTION
The client by default ignores block change events, which took far longer than it should have to track down. This PR adds a default block change handler.
