### PR TITLE
Read correct packet lengths for HeldItemChange

### DIFF
--- a/source/Craft.Net.Networking/Packets.cs
+++ b/source/Craft.Net.Networking/Packets.cs
@@ -677,7 +677,10 @@ namespace Craft.Net.Networking
 
         public NetworkMode ReadPacket(MinecraftStream stream, NetworkMode mode, PacketDirection direction)
         {
-            Slot = stream.ReadInt16();
+            if (direction == PacketDirection.Clientbound)
+                Slot = stream.ReadInt8();
+            else
+                Slot = stream.ReadInt16();
             return mode;
         }
 


### PR DESCRIPTION
The HeldItemChange packet is different sizes depending on what direction it is going in, because logic.
